### PR TITLE
Update README regarding how to init with yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ If you're already using npm scripts, you can get up and going really quickly wit
 ```
 or
 ```
-./node_modules/.bin/nps init --type yaml
+./node_modules/.bin/nps init --type yml
 ```
 
 This will use your `package.json` `scripts` to generate a `package-scripts.js` (respectively a `package-scripts.yml`)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Changes README to document that you need to pass `yml` instead of `yaml`

<!-- Why are these changes necessary? -->
**Why**: `yaml` is not a valid option according to the CLI output of nps

<!-- How were these changes implemented? -->
**How**: N/A, documentation edit

<!-- feel free to add additional comments -->
`nps` only allows `yml` not `yaml`. Once I fixed this, I still couldn't get it to work (something about the path to the package.json being null), but you at least need to pass `yml` to even get to that point.