### PR TITLE
refactor(cli): display which script is executed

### DIFF
--- a/cli-test/__snapshots__/cli.test.js.snap
+++ b/cli-test/__snapshots__/cli.test.js.snap
@@ -12,7 +12,7 @@ lint.sub.hiddenThing
 exports[`test with --require 1`] = `
 Object {
   "stderr": "",
-  "stdout": "nps executing: echo \"log\"
+  "stdout": "nps is executing \`log\`: echo \"log\"
 log
 ",
 }
@@ -37,8 +37,17 @@ Object {
 exports[`test with config with default script 1`] = `
 Object {
   "stderr": "",
-  "stdout": "nps executing: echo \"default script\"
+  "stdout": "nps is executing \`default\`: echo \"default script\"
 default script
+",
+}
+`;
+
+exports[`test with prefix 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "nps is executing \`lint.sub.thing.script\`: echo \"deeply nested thing\"
+deeply nested thing
 ",
 }
 `;

--- a/cli-test/cli.test.js
+++ b/cli-test/cli.test.js
@@ -17,6 +17,9 @@ test('with --require', () =>
 test('with --get-yargs-completions', () =>
   snapshot('--config ./package-scripts.js --get-yargs-completions li'))
 
+test('with prefix', () =>
+  snapshot('--config ./package-scripts.js lint.s.t.s'))
+
 function snapshot(args) {
   return runNPS(fixturesPath, args).then(results => {
     const snapshottableResults = convertResultToLinuxSpecific(results)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "js-yaml": "^3.7.0",
     "lodash": "^4.17.4",
     "manage-path": "^2.0.0",
-    "prefix-matches": "^0.0.9",
+    "prefix-matches": "^1.0.1",
     "readline-sync": "^1.4.6",
     "spawn-command-with-kill": "^1.0.0",
     "type-detect": "^4.0.0",

--- a/src/bin-utils/initialize/index.js
+++ b/src/bin-utils/initialize/index.js
@@ -55,22 +55,24 @@ function generatePackageScriptsFileContents(scripts) {
 
 function structureScripts(scripts) {
   // start out by giving every script a `default`
-  const defaultedScripts = Object.keys(scripts).reduce((obj, key) => {
-    const keyParts = key.split(':')
-    const isKeyScriptHook = isScriptHook(keyParts[0]);
-    let deepKey = keyParts.map(key => camelCase(key)).join('.')
+  const defaultedScripts = Object.keys(scripts).reduce((obj, scriptKey) => {
+    const keyParts = scriptKey.split(':')
+    const isKeyScriptHook = isScriptHook(keyParts[0])
+    const deepKey = keyParts.map(key => camelCase(key)).join('.')
     let defaultDeepKey = `${deepKey}.default`
-    if (key.indexOf('start') === 0) {
+    if (scriptKey.indexOf('start') === 0) {
       defaultDeepKey = [
         'default',
         ...keyParts.slice(1, keyParts.length),
         'default',
       ].join('.')
     }
-    let script = scripts[key]
+    let script = scripts[scriptKey]
     if (!isKeyScriptHook) {
-      const preHook = scripts[`pre${key}`] ? `nps pre${deepKey} && ` : ''
-      const postHook = scripts[`post${key}`] ? ` && nps post${deepKey}` : ''
+      const preHook = scripts[`pre${scriptKey}`] ? `nps pre${deepKey} && ` : ''
+      const postHook = scripts[`post${scriptKey}`] ?
+        ` && nps post${deepKey}` :
+        ''
       script = `${preHook}${script}${postHook}`
     }
     set(obj, defaultDeepKey, script)
@@ -132,4 +134,4 @@ function isLast(object, index) {
 
 function isScriptHook(script) {
   return script.indexOf('pre') === 0 || script.indexOf('post') === 0
-} 
+}

--- a/src/bin-utils/initialize/index.test.js
+++ b/src/bin-utils/initialize/index.test.js
@@ -14,7 +14,7 @@ test('initialize JS normally', () => {
   const expectedPackageScripts = readFileSync(
     resolve('./src/bin-utils/initialize/fixtures/_package-scripts.js'),
     'utf-8',
-  ).replace(/\r?\n/g, '\n');
+  ).replace(/\r?\n/g, '\n')
   const mockWriteFileSync = spy()
   const mockFindUpSync = spy(file => {
     if (file === 'package.json') {

--- a/src/get-script-to-run.test.js
+++ b/src/get-script-to-run.test.js
@@ -2,12 +2,15 @@ import getScriptToRun from './get-script-to-run'
 
 test('allows a prefix to be provided', () => {
   const script = getScriptToRun({build: 'stuff'}, 'b')
-  expect(script).toBe('stuff')
+  expect(script).toEqual({scriptName: 'build', script: 'stuff'})
 })
 
 test('allows a multi-level prefix to be provided', () => {
   const script = getScriptToRun({build: {watch: 'watch stuff'}}, 'b.w')
-  expect(script).toBe('watch stuff')
+  expect(script).toEqual({
+    scriptName: 'build.watch',
+    script: 'watch stuff',
+  })
 })
 
 test(
@@ -17,7 +20,10 @@ test(
       {build: {watch: 'watch stuff'}},
       'build.watch',
     )
-    expect(script).toBe('watch stuff')
+    expect(script).toEqual({
+      scriptName: 'build.watch',
+      script: 'watch stuff',
+    })
   },
 )
 
@@ -26,7 +32,10 @@ test('can accept snake-case representation of a camelCase name', () => {
     {checkCoverage: 'checking coverage'},
     'check-coverage',
   )
-  expect(script).toBe('checking coverage')
+  expect(script).toEqual({
+    scriptName: 'check-coverage',
+    script: 'checking coverage',
+  })
 })
 
 test('fallsback to `default` if no prefix is found', () => {
@@ -35,7 +44,13 @@ test('fallsback to `default` if no prefix is found', () => {
   const defaultIsPrefixFallback = getScriptToRun(scripts, 'foo.def')
   const script = getScriptToRun(scripts, 'foo.de')
 
-  expect(usesDefault).toBe('echo "default"')
-  expect(defaultIsPrefixFallback).toBe('echo "default"')
-  expect(script).toBe('echo "dee"')
+  expect(usesDefault).toEqual({
+    scriptName: 'foo',
+    script: 'echo "default"',
+  })
+  expect(defaultIsPrefixFallback).toEqual({
+    scriptName: 'foo.default',
+    script: 'echo "default"',
+  })
+  expect(script).toEqual({scriptName: 'foo.dee', script: 'echo "dee"'})
 })

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function runPackageScripts({scriptConfig, scripts, options = {}}) {
 function runPackageScript({scriptConfig, options, input}) {
   const [scriptPrefix, ...args] = input.split(' ')
   const scripts = getScriptsFromConfig(scriptConfig, scriptPrefix)
-  const script = getScriptToRun(scripts, scriptPrefix)
+  const {scriptName, script} = getScriptToRun(scripts, scriptPrefix)
   if (!isString(script)) {
     return Promise.reject({
       message: chalk.red(
@@ -56,7 +56,13 @@ function runPackageScript({scriptConfig, options, input}) {
   }
   const command = [script, ...args].join(' ').trim()
   const log = getLogger(getLogLevel(options))
-  log.info(chalk.gray('nps executing: ') + chalk.green(command))
+  log.info(
+    oneLine`
+    ${chalk.gray('nps is executing')}
+     \`${chalk.bold(scriptName)}\`:
+     ${chalk.green(command)}
+     `,
+  )
   let child
   return new Promise((resolve, reject) => {
     child = spawn(command, {stdio: 'inherit', env: getEnv()})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4435,6 +4435,13 @@ prefix-matches@^0.0.9:
     is-object "^1.0.1"
     starts-with "^1.0.2"
 
+prefix-matches@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prefix-matches/-/prefix-matches-1.0.1.tgz#02e34ce27f33af48e68bbfce2aac2a004bc2b76c"
+  dependencies:
+    is-object "^1.0.1"
+    starts-with "^1.0.2"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
Added an additional information displaying which script is executed.

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Added information which script is executed.

<!-- Why are these changes necessary? -->
**Why**: Because of #126 

<!-- How were these changes implemented? -->
**How**: Just added an additional chalk call and changed string concatenation for template literal.


<!-- feel free to add additional comments -->
