### PR TITLE
Add support to display help for one specific script

### DIFF
--- a/src/bin-utils/index.test.js
+++ b/src/bin-utils/index.test.js
@@ -3,7 +3,13 @@ import path from 'path'
 import chalk from 'chalk'
 import {spy} from 'sinon'
 import {oneLine} from 'common-tags'
-import {help, preloadModule, loadConfig} from './index'
+import {
+  help,
+  preloadModule,
+  loadConfig,
+  stringifyScript,
+  specificHelpScript,
+} from './index'
 
 test('preloadModule: resolves a relative path', () => {
   // this is relative to process.cwd() I think...
@@ -304,6 +310,69 @@ test(
     expect(message).toBe(expected)
   },
 )
+
+test('specificHelpScript: returns no script available', () => {
+  const config = {scripts: {}}
+  const message = specificHelpScript(config, 'foo')
+  const expected = chalk.yellow('Script foo does not exist')
+  expect(message).toBe(expected)
+})
+
+test(
+  'specificHelpScript: do not display script with flag hiddenFromHelp=true',
+  () => {
+    const config = {
+      scripts: {
+        foo: {
+          description: 'the foo script',
+          script: 'echo "foo"',
+          hiddenFromHelp: true,
+        },
+      },
+    }
+    const message = specificHelpScript(config, 'foo')
+    const expected = chalk.yellow('Script foo does not exist')
+    expect(message).toBe(expected)
+  },
+)
+
+test('specificHelpScript: formats a nice message', () => {
+  const config = {
+    scripts: {
+      foo: {
+        description: 'the foo script',
+        script: 'echo "foo"',
+      },
+    },
+  }
+  const message = specificHelpScript(config, 'foo')
+  // normally I'd use snapshot testing
+  // but the colors here are easier to think about
+  // than `[32mfoobar[39m` sooo....
+  const expected = `
+
+  ${chalk.green('foo')} - ${chalk.white('the foo script')} - ${chalk.gray('echo "foo"')}
+  `.trim()
+
+  expect(message).toBe(expected)
+})
+
+test('stringifyScript: formats a nice message', () => {
+  const script = {
+    name: 'foo',
+    description: 'the foo script',
+    script: 'echo "foo"',
+  }
+  const message = stringifyScript(script)
+  // normally I'd use snapshot testing
+  // but the colors here are easier to think about
+  // than `[32mfoobar[39m` sooo....
+  const expected = `
+  ${chalk.green('foo')} - ${chalk.white('the foo script')} - ${chalk.gray('echo "foo"')}
+  `.trim()
+
+  expect(message).toBe(expected)
+})
 
 function getAbsoluteFixturePath(fixture) {
   return path.join(__dirname, 'fixtures', fixture)

--- a/src/bin-utils/parser.js
+++ b/src/bin-utils/parser.js
@@ -5,7 +5,13 @@ import {keyInYN} from 'readline-sync'
 import {includes, isEqual} from 'lodash'
 import {oneLine} from 'common-tags'
 import getLogger from '../get-logger'
-import {preloadModule, loadConfig, initialize, help} from '../bin-utils'
+import {
+  preloadModule,
+  loadConfig,
+  initialize,
+  help,
+  specificHelpScript,
+} from '../bin-utils'
 import getCompletionScripts from './autocomplete-get-scripts'
 
 const log = getLogger()
@@ -66,7 +72,6 @@ function parse(rawArgv) {
     .exitProcess(shouldExitProcess())
 
   const parsedArgv = parser.parse(rawArgv)
-
   if (commandExecuted) {
     return undefined
   }
@@ -110,8 +115,14 @@ function parse(rawArgv) {
     const noScriptSpecifiedAndNoDefault = !specifiedScripts.length &&
       !hasDefaultScript
     const hasHelpScript = Boolean(psConfig.scripts.help)
-    const commandIsHelp = isEqual(specifiedScripts, ['help']) && !hasHelpScript
-    if (commandIsHelp || noScriptSpecifiedAndNoDefault) {
+    const commandIsHelp = isEqual(specifiedScripts[0], 'help') &&
+      !hasHelpScript
+    const shouldShowSpecificScriptHelp = commandIsHelp &&
+      specifiedScripts.length > 1
+    if (shouldShowSpecificScriptHelp) {
+      log.info(specificHelpScript(psConfig, specifiedScripts[1]))
+      return true
+    } else if (commandIsHelp || noScriptSpecifiedAndNoDefault) {
       parser.showHelp('log')
       log.info(help(psConfig))
       return true

--- a/src/bin-utils/parser.test.js
+++ b/src/bin-utils/parser.test.js
@@ -27,6 +27,7 @@ jest.mock('../bin-utils', () => {
       }
     }),
     help: jest.fn(),
+    specificHelpScript: jest.fn(),
     clearAll,
     mock: {},
   }
@@ -202,6 +203,23 @@ test(
     mockBinUtils.mock.psConfig = {scripts: {help: 'hi'}}
     expect(parse('help')).not.toBe(undefined)
     expect(mockGetLogger.mock.info).toHaveBeenCalledTimes(0)
+  },
+)
+
+test(
+  'if help is called with a script, it shows the help for that script',
+  () => {
+    mockBinUtils.mock.psConfig = {
+      scripts: {
+        foo: {
+          description: 'the foo script',
+          script: 'echo "foo"',
+        },
+      },
+    }
+    expect(parse('help foo')).toBe(undefined)
+    expect(mockBinUtils.specificHelpScript).toHaveBeenCalledTimes(1)
+    expect(mockGetLogger.mock.info).toHaveBeenCalledTimes(1)
   },
 )
 


### PR DESCRIPTION
**What**

Support help for specific scripts. "npm help build" will now log the script info for the script "build".

** Why **
Fixes issue #61 

** How**
1. Extracted a function `stringifyScript` out of help which renders one script as a message.
2. Used the `stringifyScript` function within a new function `specificHelpScript` to display help information for a script instead of `help` in said scenario.
3. Wrote tests to cover the scenario.
