### PR TITLE
Fix scriptname

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function runPackageScripts({scriptConfig, scripts, options = {}}) {
 function runPackageScript({scriptConfig, options, input}) {
   const [scriptPrefix, ...args] = input.split(' ')
   const scripts = getScriptsFromConfig(scriptConfig, scriptPrefix)
-  const {scriptName, script} = getScriptToRun(scripts, scriptPrefix)
+  const {scriptName, script} = getScriptToRun(scripts, scriptPrefix) || {}
   if (!isString(script)) {
     return Promise.reject({
       message: chalk.red(

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -151,6 +151,23 @@ test('runs the default script if no scripts provided', () => {
   })
 })
 
+test('returns a log object when a script does not exist', () => {
+  const {runPackageScript} = setup()
+  const scriptConfig = {lint: {script: 42}}
+  return runPackageScript({scriptConfig, scripts: ['dev']}).catch(error => {
+    expect(error).toEqual({
+      message: chalk.red(
+        oneLine`
+          Scripts must resolve to strings.
+          There is no script that can be
+          resolved from "dev"
+        `,
+      ),
+      ref: 'missing-script',
+    })
+  })
+})
+
 test('an error from the child process logs an error', () => {
   const ERROR = {message: 'there was an error', code: 2}
   const badCommand = 'bad'


### PR DESCRIPTION
**What**:
Handle missing scripts gracefully
Add test cases to cover the same.

**Why**:
Fix #145 

**How**:
Add `|| {}` , to prevent destructuring on `undefined`.
