### PR TITLE
feat: Add util to get a string based on prefix from a config

### DIFF
--- a/src/bin-utils/get-script-by-prefix.js
+++ b/src/bin-utils/get-script-by-prefix.js
@@ -1,0 +1,60 @@
+import prefixMatches from 'prefix-matches'
+import {keys, isPlainObject, isString, has} from 'lodash'
+
+/*
+  Converts a string or object with a "script" key into an object with
+   {
+    name,
+    script,
+    description
+   }
+*/
+export function scriptToObject(name, scriptArg) {
+  if (isString(scriptArg)) {
+    return {
+      name,
+      script: scriptArg,
+      description: '',
+    }
+  }
+  if (isPlainObject(scriptArg)) {
+    if (has(scriptArg, 'default')) {
+      return scriptToObject(`${name}.default`, scriptArg.default)
+    } else {
+      const description = scriptArg.description || ''
+      const script = scriptArg.script
+      return {
+        name,
+        description,
+        script,
+      }
+    }
+  }
+  return null
+}
+
+export function isValidScript(script) {
+  if (isString(script)) {
+    return true
+  } else if (isPlainObject(script)) {
+    if (has(script, 'default')) {
+      return isValidScript(script.default)
+    }
+    return has(script, 'script')
+  } else {
+    return false
+  }
+}
+
+export default function getScriptByPrefix({scripts}, prefix) {
+  const matches = prefixMatches(prefix, scripts)
+  for (const match of matches) {
+    const matchedKeys = keys(match)
+    const name = matchedKeys[0]
+    const script = match[name]
+    if (isValidScript(script)) {
+      return scriptToObject(name, script)
+    }
+  }
+  return null
+}

--- a/src/bin-utils/get-script-by-prefix.js
+++ b/src/bin-utils/get-script-by-prefix.js
@@ -33,7 +33,7 @@ export function scriptToObject(name, scriptArg) {
   return null
 }
 
-export function isValidScript(script) {
+function isValidScript(script) {
   if (isString(script)) {
     return true
   } else if (isPlainObject(script)) {
@@ -48,13 +48,32 @@ export function isValidScript(script) {
 
 export default function getScriptByPrefix({scripts}, prefix) {
   const matches = prefixMatches(prefix, scripts)
+  // This array holds all the valid scripts in
+  // the order of priority (default scripts have lowest priority)
+  const matchedScriptsSortedByPriority = []
   for (const match of matches) {
     const matchedKeys = keys(match)
     const name = matchedKeys[0]
     const script = match[name]
     if (isValidScript(script)) {
-      return scriptToObject(name, script)
+      if (has(script, 'default')) {
+        // if it's a default script, push to the last of the array
+        matchedScriptsSortedByPriority.push({
+          name,
+          script,
+        })
+      } else {
+        // if it's not a default script, push to the first of the array
+        matchedScriptsSortedByPriority.unshift({
+          name,
+          script,
+        })
+      }
     }
+  }
+  if (matchedScriptsSortedByPriority.length) {
+    const {name, script} = matchedScriptsSortedByPriority[0]
+    return scriptToObject(name, script)
   }
   return null
 }

--- a/src/bin-utils/get-script-by-prefix.test.js
+++ b/src/bin-utils/get-script-by-prefix.test.js
@@ -265,19 +265,6 @@ describe(
       },
     )
 
-    test(
-      'Resolves a script when prefix can match default script as well',
-      () => {
-        const actual = getScriptByPrefix(config, 'f.b.d')
-        const expected = {
-          script: 'echo define',
-          name: 'foo.bar.define',
-          description: '',
-        }
-        expect(actual).toEqual(expected)
-      },
-    )
-
     test('Resolves default script when prefix def has no other match', () => {
       const actual = getScriptByPrefix(config, 'f.j.def')
       const expected = {

--- a/src/bin-utils/get-script-by-prefix.test.js
+++ b/src/bin-utils/get-script-by-prefix.test.js
@@ -1,0 +1,224 @@
+import {isPlainObject, isNull} from 'lodash'
+import getScriptByPrefix, {scriptToObject} from './get-script-by-prefix'
+
+test('scriptToObject returns null when script is not object or string ', () => {
+  const actual = scriptToObject('foo', 42)
+  expect(isNull(actual)).toBeTruthy()
+})
+
+test('scriptToObject returns non-null object when script is string ', () => {
+  const actual = scriptToObject('foo', 'hello')
+  expect(isPlainObject(actual)).toBeTruthy()
+  expect(isNull(actual)).toBeFalsy()
+})
+
+test('scriptToObject returns non-null object when script is string ', () => {
+  const scriptArg = {
+    script: 'hello',
+  }
+  const actual = scriptToObject('foo', scriptArg)
+  expect(isPlainObject(actual)).toBeTruthy()
+  expect(isNull(actual)).toBeFalsy()
+})
+
+test('getScriptByPrefix returns null when no matching script', () => {
+  const config = {scripts: {}}
+  const message = getScriptByPrefix(config, 'w')
+  expect(isNull(message)).toBeTruthy()
+})
+
+test('getScriptByPrefix returns null when no matching script', () => {
+  const config = {scripts: {}}
+  const message = getScriptByPrefix(config, 'w.a.b')
+  expect(isNull(message)).toBeTruthy()
+})
+
+test('getScriptByPrefix resolves single prefixes with string values', () => {
+  const config = {
+    scripts: {
+      watch: 'echo watch',
+    },
+  }
+  const actual = getScriptByPrefix(config, 'w')
+  const expected = {
+    script: 'echo watch',
+    name: 'watch',
+    description: '',
+  }
+  expect(actual).toEqual(expected)
+})
+
+test('getScriptByPrefix resolves nested prefixes with string values', () => {
+  const config = {
+    scripts: {
+      watch: {
+        js: {
+          foo: 'echo foo',
+        },
+      },
+    },
+  }
+  const actual = getScriptByPrefix(config, 'w.j.f')
+  const expected = {
+    script: 'echo foo',
+    name: 'watch.js.foo',
+    description: '',
+  }
+  expect(actual).toEqual(expected)
+})
+
+test(
+  'getScriptByPrefix resolves single prefixes with object values && script key',
+  () => {
+    const config = {
+      scripts: {
+        foo: {
+          description: 'Foo script',
+          script: 'echo foo',
+        },
+      },
+    }
+    const actual = getScriptByPrefix(config, 'f')
+    const expected = {
+      script: 'echo foo',
+      name: 'foo',
+      description: 'Foo script',
+    }
+    expect(actual).toEqual(expected)
+  },
+)
+
+test(
+  'getScriptByPrefix resolves nested prefixes with object values && script key',
+  () => {
+    const config = {
+      scripts: {
+        watch: {
+          foo: {
+            description: 'Foo script',
+            script: 'echo foo',
+          },
+        },
+      },
+    }
+    const actual = getScriptByPrefix(config, 'w.f')
+    const expected = {
+      script: 'echo foo',
+      name: 'watch.foo',
+      description: 'Foo script',
+    }
+    expect(actual).toEqual(expected)
+  },
+)
+
+test('getScriptByPrefix resolves ambiguities with single prefix', () => {
+  const config = {
+    scripts: {
+      foo: {
+        js: {
+          default: 'foo.js script',
+          script: 'echo foo.js',
+        },
+      },
+      foobar: {
+        description: 'Foobar script',
+        script: 'echo foobar',
+      },
+    },
+  }
+  const actual = getScriptByPrefix(config, 'f')
+  const expected = {
+    script: 'echo foobar',
+    name: 'foobar',
+    description: 'Foobar script',
+  }
+  expect(actual).toEqual(expected)
+})
+
+describe('getScriptByPrefix resolves ambiguities with nested prefix', () => {
+  let config
+  beforeEach(() => {
+    config = {
+      scripts: {
+        foo: {
+          bar: {
+            default: 'echo foo.bar',
+            baz: {
+              default: 'echo foo.bar.baz',
+              joe: {
+                default: {
+                  script: 'echo foo.bar.baz.joe',
+                },
+              },
+              invalid: 42,
+              s: {
+                t: 'echo t',
+              },
+            },
+          },
+        },
+        foobar: {
+          description: 'Foobar script',
+          script: 'echo foobar',
+        },
+      },
+    }
+  })
+  test('Foobar works correctly', () => {
+    const actual = getScriptByPrefix(config, 'f')
+    const expected = {
+      script: 'echo foobar',
+      name: 'foobar',
+      description: 'Foobar script',
+    }
+    expect(actual).toEqual(expected)
+  })
+  test('foo.bar works correctly', () => {
+    const actual = getScriptByPrefix(config, 'f.b')
+    const expected = {
+      script: 'echo foo.bar',
+      name: 'foo.bar.default',
+      description: '',
+    }
+    expect(actual).toEqual(expected)
+  })
+  test('foo.bar.baz works correctly', () => {
+    const actual = getScriptByPrefix(config, 'f.b.b')
+    const expected = {
+      script: 'echo foo.bar.baz',
+      name: 'foo.bar.baz.default',
+      description: '',
+    }
+    expect(actual).toEqual(expected)
+  })
+  test('foo.bar.baz.joe works correctly', () => {
+    const actual = getScriptByPrefix(config, 'f.b.b.j')
+    const expected = {
+      script: 'echo foo.bar.baz.joe',
+      name: 'foo.bar.baz.joe.default',
+      description: '',
+    }
+    expect(actual).toEqual(expected)
+  })
+  test('foo.bar.baz.x returns null', () => {
+    const actual = getScriptByPrefix(config, 'f.b.b.x')
+    expect(isNull(actual)).toBeTruthy()
+  })
+  test('f.x returns null', () => {
+    const actual = getScriptByPrefix(config, 'f.x')
+    expect(isNull(actual)).toBeTruthy()
+  })
+  test('d as prefix matches default', () => {
+    const actual = getScriptByPrefix(config, 'f.b.b.d')
+    const expected = {
+      name: 'foo.bar.baz.default',
+      description: '',
+      script: 'echo foo.bar.baz',
+    }
+    expect(actual).toEqual(expected)
+  })
+  test('returns null when script is a number', () => {
+    const actual = getScriptByPrefix(config, 'f.b.b.i')
+    expect(isNull(actual)).toBeTruthy()
+  })
+})

--- a/src/bin-utils/get-script-by-prefix.test.js
+++ b/src/bin-utils/get-script-by-prefix.test.js
@@ -1,15 +1,15 @@
-import {isPlainObject, isNull} from 'lodash'
+import {isPlainObject} from 'lodash'
 import getScriptByPrefix, {scriptToObject} from './get-script-by-prefix'
 
 test('scriptToObject returns null when script is not object or string ', () => {
   const actual = scriptToObject('foo', 42)
-  expect(isNull(actual)).toBeTruthy()
+  expect(actual).toBeNull()
 })
 
 test('scriptToObject returns non-null object when script is string ', () => {
   const actual = scriptToObject('foo', 'hello')
   expect(isPlainObject(actual)).toBeTruthy()
-  expect(isNull(actual)).toBeFalsy()
+  expect(actual).not.toBeNull()
 })
 
 test('scriptToObject returns non-null object when script is string ', () => {
@@ -18,19 +18,19 @@ test('scriptToObject returns non-null object when script is string ', () => {
   }
   const actual = scriptToObject('foo', scriptArg)
   expect(isPlainObject(actual)).toBeTruthy()
-  expect(isNull(actual)).toBeFalsy()
+  expect(actual).not.toBeNull()
 })
 
 test('getScriptByPrefix returns null when no matching script', () => {
   const config = {scripts: {}}
   const message = getScriptByPrefix(config, 'w')
-  expect(isNull(message)).toBeTruthy()
+  expect(message).toBeNull()
 })
 
 test('getScriptByPrefix returns null when no matching script', () => {
   const config = {scripts: {}}
   const message = getScriptByPrefix(config, 'w.a.b')
-  expect(isNull(message)).toBeTruthy()
+  expect(message).toBeNull()
 })
 
 test('getScriptByPrefix resolves single prefixes with string values', () => {
@@ -202,11 +202,11 @@ describe('getScriptByPrefix resolves ambiguities with nested prefix', () => {
   })
   test('foo.bar.baz.x returns null', () => {
     const actual = getScriptByPrefix(config, 'f.b.b.x')
-    expect(isNull(actual)).toBeTruthy()
+    expect(actual).toBeNull()
   })
   test('f.x returns null', () => {
     const actual = getScriptByPrefix(config, 'f.x')
-    expect(isNull(actual)).toBeTruthy()
+    expect(actual).toBeNull()
   })
   test('d as prefix matches default', () => {
     const actual = getScriptByPrefix(config, 'f.b.b.d')
@@ -219,6 +219,73 @@ describe('getScriptByPrefix resolves ambiguities with nested prefix', () => {
   })
   test('returns null when script is a number', () => {
     const actual = getScriptByPrefix(config, 'f.b.b.i')
-    expect(isNull(actual)).toBeTruthy()
+    expect(actual).toBeNull()
   })
 })
+
+describe(
+  'getScriptByPrefix resolves ambiguities with defaults correctly',
+  () => {
+    let config
+    beforeEach(() => {
+      config = {
+        scripts: {
+          foo: {
+            bar: {
+              default: 'echo foo.bar',
+              define: 'echo define',
+            },
+            john: {
+              default: 'echo foo.john',
+            },
+          },
+        },
+      }
+    })
+    test('Resolves default when a prefix is not deep enough', () => {
+      const actual = getScriptByPrefix(config, 'f.b')
+      const expected = {
+        script: 'echo foo.bar',
+        name: 'foo.bar.default',
+        description: '',
+      }
+      expect(actual).toEqual(expected)
+    })
+
+    test(
+      'Resolves a script when prefix can match default script as well',
+      () => {
+        const actual = getScriptByPrefix(config, 'f.b.d')
+        const expected = {
+          script: 'echo define',
+          name: 'foo.bar.define',
+          description: '',
+        }
+        expect(actual).toEqual(expected)
+      },
+    )
+
+    test(
+      'Resolves a script when prefix can match default script as well',
+      () => {
+        const actual = getScriptByPrefix(config, 'f.b.d')
+        const expected = {
+          script: 'echo define',
+          name: 'foo.bar.define',
+          description: '',
+        }
+        expect(actual).toEqual(expected)
+      },
+    )
+
+    test('Resolves default script when prefix def has no other match', () => {
+      const actual = getScriptByPrefix(config, 'f.j.def')
+      const expected = {
+        script: 'echo foo.john',
+        name: 'foo.john.default',
+        description: '',
+      }
+      expect(actual).toEqual(expected)
+    })
+  },
+)


### PR DESCRIPTION
**What**:
This commit adds a util get-sript-by-prefix.js to bin/utils which takes in a config and a prefix
string as arguments and returns a script if it finds a match, or returns null

**Why**:
This util will help with the issue being fixed in #146 

**How**:
Added a util 'get-string-by-prefix.js' which takes in a config and prefix as arguments and returns a script object if found. Otherwise it returns null.

The script object has the following structure 
`{
   name,
  description,
  script
}`

<!-- feel free to add additional comments -->
