### PR TITLE
test: Use jest mock instead of sinon spy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "bin": {
     "nps": "./dist/bin/nps.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
@@ -51,17 +53,23 @@
     "nps": "^5.4.0",
     "nps-utils": "^1.2.0",
     "opt-cli": "^1.5.1",
-    "prettier-eslint-cli": "^4.1.1",
-    "sinon": "^3.2.1"
+    "prettier-eslint-cli": "^4.1.1"
   },
   "eslintConfig": {
-    "extends": ["kentcdodds", "kentcdodds/jest", "kentcdodds/prettier"],
+    "extends": [
+      "kentcdodds",
+      "kentcdodds/jest",
+      "kentcdodds/prettier"
+    ],
     "rules": {
       "max-len": "off"
     }
   },
   "lint-staged": {
-    "*.js": ["prettier-eslint --write", "git add"]
+    "*.js": [
+      "prettier-eslint --write",
+      "git add"
+    ]
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/get-scripts-from-config.js
+++ b/src/__tests__/get-scripts-from-config.js
@@ -1,4 +1,3 @@
-import {spy} from 'sinon'
 import getScriptsFromConfig from '../get-scripts-from-config'
 
 test('returns empty object by default', () => {
@@ -7,11 +6,10 @@ test('returns empty object by default', () => {
 
 test('passes input to the scripts if it is a function', () => {
   const input = 'hello'
-  const scripts = spy()
+  const scripts = jest.fn()
   getScriptsFromConfig(scripts, input)
-  expect(scripts.calledOnce).toBe(true)
-  const [firstArg] = scripts.firstCall.args
-  expect(firstArg).toBe(input)
+  expect(scripts).toHaveBeenCalledTimes(1)
+  expect(scripts).toHaveBeenCalledWith(input)
 })
 
 test('just uses the scripts object if it is an object', () => {

--- a/src/bin-utils/__tests__/index.js
+++ b/src/bin-utils/__tests__/index.js
@@ -1,7 +1,6 @@
 /* eslint import/newline-after-import:0, global-require:0 */
 import path from 'path'
 import chalk from 'chalk'
-import {spy} from 'sinon'
 import {oneLine} from 'common-tags'
 import {help, preloadModule, loadConfig, specificHelpScript} from '../'
 
@@ -25,14 +24,14 @@ test('preloadModule: resolves a node_module', () => {
 })
 
 test('preloadModule: logs a warning when the module cannot be required', () => {
-  const mockWarn = spy()
+  const mockWarn = jest.fn()
   jest.resetModules()
   jest.mock('../../get-logger', () => () => ({warn: mockWarn}))
   const {preloadModule: proxiedPreloadModule} = require('../')
   const val = proxiedPreloadModule('./module-that-does-exist')
   expect(val).toBeUndefined()
-  expect(mockWarn.calledOnce).toBe(true)
-  const [{message}] = mockWarn.firstCall.args
+  expect(mockWarn).toHaveBeenCalledTimes(1)
+  const [[{message}]] = mockWarn.mock.calls
   expect(message).toMatch(/Unable to preload "\.\/module-that-does-exist"/)
 })
 
@@ -147,14 +146,14 @@ test(
 )
 
 test('loadConfig: logs a warning when the JS module cannot be required', () => {
-  const mockError = spy()
+  const mockError = jest.fn()
   jest.resetModules()
   jest.mock('../../get-logger', () => () => ({error: mockError}))
   const {loadConfig: proxiedReloadConfig} = require('../')
   const val = proxiedReloadConfig('./config-that-does-exist')
   expect(val).toBeUndefined()
-  expect(mockError.calledOnce).toBe(true)
-  const [{message}] = mockError.firstCall.args
+  expect(mockError).toHaveBeenCalledTimes(1)
+  const [[{message}]] = mockError.mock.calls
   expect(message).toMatch(
     /Unable to find JS config at "\.\/config-that-does-exist"/,
   )
@@ -197,14 +196,14 @@ test('loadConfig: does not swallow YAML syntax errors', () => {
 })
 
 test('loadConfig: logs a warning when the YAML file cannot be located', () => {
-  const mockError = spy()
+  const mockError = jest.fn()
   jest.resetModules()
   jest.mock('../../get-logger', () => () => ({error: mockError}))
   const {loadConfig: proxiedReloadConfig} = require('../')
   const val = proxiedReloadConfig('./config-that-does-not-exist.yml')
   expect(val).toBeUndefined()
-  expect(mockError.calledOnce).toBe(true)
-  const [{message}] = mockError.firstCall.args
+  expect(mockError).toHaveBeenCalledTimes(1)
+  const [[{message}]] = mockError.mock.calls
   expect(message).toMatch(
     /Unable to find YML config at "\.\/config-that-does-not-exist.yml"/,
   )


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Use `jest.fn` instead of `sinon.spy`, remove `sinon` dependency

<!-- Why are these changes necessary? -->
**Why**: `jest` already provides the functionality necessary for testing mock functions. So no need to have `sinon` as a dependency.

<!-- How were these changes implemented? -->
**How**: Refactored the tests to use `jest.fn`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
This was discussed in https://github.com/kentcdodds/nps/pull/161#issuecomment-325157877.