### PR TITLE
fix: default config values for yml files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "all-contributors-cli": "^4.3.0",
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
-    "babel-jest": "^20.0.3",
-    "babel-plugin-module-resolver": "^2.7.1",
+    "babel-jest": "^22.0.0",
+    "babel-plugin-module-resolver": "^3.0.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.24.1",
@@ -48,8 +48,8 @@
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jest": "20.0.3",
     "husky": "0.14.3",
-    "jest-cli": "^20.0.4",
-    "lint-staged": "^4.0.1",
+    "jest-cli": "^22.0.0",
+    "lint-staged": "^7.0.0",
     "nps": "^5.4.0",
     "nps-utils": "^1.2.0",
     "opt-cli": "^1.5.1",
@@ -62,7 +62,8 @@
       "kentcdodds/prettier"
     ],
     "rules": {
-      "max-len": "off"
+      "max-len": "off",
+      "max-lines": "off"
     }
   },
   "lint-staged": {

--- a/src/bin-utils/__tests__/fixtures/fake-config.yml
+++ b/src/bin-utils/__tests__/fixtures/fake-config.yml
@@ -1,4 +1,2 @@
 scripts:
     skywalker: echo "That's impossible!!"
-
-options: {}

--- a/src/bin-utils/__tests__/index.js
+++ b/src/bin-utils/__tests__/index.js
@@ -212,14 +212,16 @@ test('loadConfig: logs a warning when the YAML file cannot be located', () => {
   )
 })
 
-test('loadConfig: can load config from YML file', () => {
+test('loadConfig: can load config from a YML file', () => {
   const relativePath = './src/bin-utils/__tests__/fixtures/fake-config.yml'
   const val = loadConfig(relativePath)
   expect(val).toEqual({
     scripts: {
       skywalker: `echo "That's impossible!!"`,
     },
-    options: {},
+    options: {
+      'help-style': 'all',
+    },
   })
 })
 

--- a/src/bin-utils/index.js
+++ b/src/bin-utils/index.js
@@ -65,11 +65,13 @@ const loadJSConfig = getAttemptModuleRequireFn(function onFail(
  */
 // eslint-disable-next-line complexity
 function loadConfig(configPath, input) {
+  let config
   if (configPath.endsWith('.yml')) {
-    return loadYAMLConfig(configPath)
+    config = loadYAMLConfig(configPath)
+  } else {
+    config = loadJSConfig(configPath)
   }
 
-  let config = loadJSConfig(configPath)
   if (isUndefined(config)) {
     // let the caller deal with this
     return config

--- a/src/bin-utils/parser.js
+++ b/src/bin-utils/parser.js
@@ -117,6 +117,7 @@ function parse(rawArgv) {
 
   // util functions
 
+  // eslint-disable-next-line complexity
   function showHelp(specifiedScripts) {
     if (parsedArgv.help) {
       // if --help was specified, then yargs will show the default help

--- a/test/jest.src.config.js
+++ b/test/jest.src.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   rootDir: '../src',
+  collectCoverage: true,
   testEnvironment: 'node',
-  collectCoverageFrom: ['src/**/*.js'],
   testPathIgnorePatterns: ['/node_modules/', '/fixtures/', '/helpers/'],
   coveragePathIgnorePatterns: [
     '/node_modules/',


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

All `nps` commands would fail given the following conditions were true:

* User was using a `package-scripts.yml` instead of a `package-scripts.js`
* User didn't pass any options to `nps`

closes #170

<!-- Why are these changes necessary? -->
**Why**:

Current implementation makes it impossible to call `nps` normally without a minor workaround of some sort.

e.g.

```yml
scripts:
  echo: echo "this is a test"

config: {}
```

<!-- How were these changes implemented? -->
**How**:

`yml` configurations now go through the same post-process as `js` configurations.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->