### PR TITLE
fix: print error on init when cannot find a package.json

### DIFF
--- a/src/bin-utils/initialize/index.js
+++ b/src/bin-utils/initialize/index.js
@@ -60,6 +60,9 @@ const CORE_SCRIPTS = [
 function initialize(configType = 'js') {
   /* eslint global-require:0,import/no-dynamic-require:0 */
   const packageJsonPath = findUpSync('package.json')
+  if (packageJsonPath === null) {
+    return
+  }
   const packageJson = require(packageJsonPath)
   const {scripts = {}} = packageJson
   packageJson.scripts = getCoreScripts(packageJson.scripts)

--- a/src/bin-utils/parser.js
+++ b/src/bin-utils/parser.js
@@ -185,7 +185,12 @@ function parse(rawArgv) {
           return
         }
       }
-      const {packageScriptsPath} = initialize(initArgv.type)
+      const init = initialize(initArgv.type)
+      if (!packageScriptsPath) {
+        log.error(chalk.red('Unable to to find an existing package.json'))
+        return
+      }
+      const packageScriptsPath = init.packageScriptsPath
       log.info(
         `Your scripts have been saved at ${chalk.green(packageScriptsPath)}`,
       )


### PR DESCRIPTION
**What**:

If a user runs `nps init` in an empty directory with no existing `package.json` the command fails with a non-user friendly error.

**How**:

If this "error" is encountered print a friendly error and exit.

**Comments**:

Instead of exiting out `nps init` could continue without any package.json scripts and use the local directory as the package-scripts.js path.
