### PR TITLE
fix: fix nps init with config yml

### DIFF
--- a/src/bin-utils/initialize/__tests__/index.js
+++ b/src/bin-utils/initialize/__tests__/index.js
@@ -60,7 +60,7 @@ test('initialize YML normally', () => {
   jest.mock('fs', () => ({writeFileSync: mockWriteFileSync}))
   const initialize = require('../').default
 
-  initialize('yaml')
+  initialize('yml')
 
   const [
     [packageJsonDestinationResult, packageJsonStringResult],

--- a/src/bin-utils/initialize/index.js
+++ b/src/bin-utils/initialize/index.js
@@ -65,7 +65,7 @@ function initialize(configType = 'js') {
   packageJson.scripts = getCoreScripts(packageJson.scripts)
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
 
-  if (configType === 'yaml') {
+  if (configType === 'yml') {
     return dumpYAMLConfig(packageJsonPath, scripts)
   }
 


### PR DESCRIPTION
**What**:

The `nps init --type yml` command is not working as expected.

**How**:

Change code to check for the same string as accepted by the parser.
